### PR TITLE
Fix for extreme missingness patterns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: lessSEM
 Type: Package
 Title: Non-Smooth Regularization for Structural Equation Models
-Version: 1.5.1
+Version: 1.5.2
 Authors@R: c(person(given   = "Jannik H.", family = "Orzek",
                     role    = c("aut", "cre", "cph"),
                     email   = "orzek@mpib-berlin.mpg.de",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# lessSEM 1.5.2
+
+* Fixed bug in extreme cases of missing data
+
 # lessSEM 1.5.0
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/SEMData.R
+++ b/R/SEMData.R
@@ -27,8 +27,8 @@
       missingSubsets[[mrow]]$N <- length(individuals)
       missingSubsets[[mrow]]$observed <- sum(!pattern)
       missingSubsets[[mrow]]$notMissing <- which(!pattern)-1
-      missingSubsets[[mrow]]$covariance <- ((length(individuals)-1)/length(individuals))*stats::cov(rawData[individuals,!pattern])
-      missingSubsets[[mrow]]$means <- apply(rawData[individuals,!pattern], 2, mean)
+      missingSubsets[[mrow]]$covariance <- ((length(individuals)-1)/length(individuals))*stats::cov(rawData[individuals,!pattern,drop = FALSE])
+      missingSubsets[[mrow]]$means <- apply(rawData[individuals,!pattern,drop = FALSE], 2, mean)
       missingSubsets[[mrow]]$rawData <- rawData[individuals,,drop=FALSE]
       missingSubsets[[mrow]]$objectiveValue <- NA
     }else{

--- a/R/class-regularizedSEM.R
+++ b/R/class-regularizedSEM.R
@@ -292,6 +292,12 @@ setMethod("fitIndices", "regularizedSEM", function(object) {
     
     if(!multiGroup){
       dataset <- lavInspect(object@inputArguments$lavaanModel, "data")
+      # remove empty rows:
+      if(any(apply(dataset,1,function(x) all(is.na(x))))){
+        warning("Your data set has rows where all observations are missing. lessSEM will",
+                "remove those rows, but it is recommended to do so before fitting the models.")
+        dataset <- dataset[!apply(dataset,1,function(x) all(is.na(x))),,drop = FALSE]
+      }
       sampstats <- lavInspect(object@inputArguments$lavaanModel, "sampstat")
       N <- nrow(dataset)
     }
@@ -314,9 +320,9 @@ setMethod("fitIndices", "regularizedSEM", function(object) {
         satPar <- nrow(sampstats$cov)*(ncol(sampstats$cov)+1)/2 + length(sampstats$mean)
       }
       
-      saturatedFit <- -2*sum(apply(dataset, 1, function(x) mvtnorm::dmvnorm(x = x[!is.na(x)], 
-                                                                            mean = sampstats$mean[!is.na(x)], 
-                                                                            sigma = sampstats$cov[!is.na(x), !is.na(x)], 
+      saturatedFit <- -2*sum(apply(dataset, 1, function(x) mvtnorm::dmvnorm(x = x[!is.na(x), drop = FALSE], 
+                                                                            mean = sampstats$mean[!is.na(x), drop = FALSE], 
+                                                                            sigma = sampstats$cov[!is.na(x), !is.na(x), drop = FALSE], 
                                                                             log = TRUE))
       )
       

--- a/R/class-regularizedSEMMixedPenalty.R
+++ b/R/class-regularizedSEMMixedPenalty.R
@@ -250,6 +250,12 @@ setMethod("fitIndices", "regularizedSEMMixedPenalty", function(object) {
     
     if(!multiGroup){
       dataset <- lavInspect(object@inputArguments$lavaanModel, "data")
+      # remove empty rows:
+      if(any(apply(dataset,1,function(x) all(is.na(x))))){
+        warning("Your data set has rows where all observations are missing. lessSEM will",
+                "remove those rows, but it is recommended to do so before fitting the models.")
+        dataset <- dataset[!apply(dataset,1,function(x) all(is.na(x))),,drop = FALSE]
+      }
       sampstats <- lavInspect(object@inputArguments$lavaanModel, "sampstat")
       N <- nrow(dataset)
     }
@@ -272,9 +278,9 @@ setMethod("fitIndices", "regularizedSEMMixedPenalty", function(object) {
         satPar <- nrow(sampstats$cov)*(ncol(sampstats$cov)+1)/2 + length(sampstats$mean)
       }
       
-      saturatedFit <- -2*sum(apply(dataset, 1, function(x) mvtnorm::dmvnorm(x = x[!is.na(x)], 
-                                                                            mean = sampstats$mean[!is.na(x)], 
-                                                                            sigma = sampstats$cov[!is.na(x), !is.na(x)], 
+      saturatedFit <- -2*sum(apply(dataset, 1, function(x) mvtnorm::dmvnorm(x = x[!is.na(x), drop = FALSE], 
+                                                                            mean = sampstats$mean[!is.na(x), drop = FALSE], 
+                                                                            sigma = sampstats$cov[!is.na(x), !is.na(x), drop = FALSE], 
                                                                             log = TRUE))
       )
       

--- a/R/cvRegularizeSEMInternal.R
+++ b/R/cvRegularizeSEMInternal.R
@@ -68,7 +68,7 @@
                                                                       control$breakOuter == controlGlmnet()$breakOuter
                                              ))
   
-  rawData <- try(lavaan::lavInspect(lavaanModel, "data"))
+  rawData <- try(.getRawData(lavaanModel, NULL, "fiml")$rawData)
   if(is(rawData, "try-error")) 
     stop("Error while extracting raw data from lavaanModel. Please fit the model using the raw data set, not the covariance matrix.")
   N <- nrow(rawData)
@@ -91,7 +91,7 @@
                                           transformations = FALSE))
   
   # check if the data was standardized:
-  if(all(apply(rawData, 2, function(x) abs(mean(x)) <= 1e-5))) 
+  if(all(apply(rawData, 2, function(x) abs(mean(x, na.rm = TRUE)) <= 1e-5))) 
     warning(paste0("It seems that you standardized your data before fitting your lavaan model. ",
                    "Note that this can undermine the results of the cross-validation due to dependencies between ",
                    "the subsets. Consider re-fitting your model with unstandardized data and use standardize = TRUE ",

--- a/R/cvRegularizeSmoothSEMInternal.R
+++ b/R/cvRegularizeSmoothSEMInternal.R
@@ -62,7 +62,7 @@
                                                                       control$breakOuter == controlGlmnet()$breakOuter
                                              ))
   
-  rawData <- try(lavaan::lavInspect(lavaanModel, "data"))
+  rawData <- try(.getRawData(lavaanModel, NULL, "fiml")$rawData)
   if(is(rawData, "try-error")) 
     stop("Error while extracting raw data from lavaanModel. Please fit the model using the raw data set, not the covariance matrix.")
   N <- nrow(rawData)
@@ -71,7 +71,7 @@
   
   parameterLabels <- names(getLavaanParameters(lavaanModel))
   
-  if(all(apply(rawData, 2, function(x) abs(mean(x)) <= 1e-5))) 
+  if(all(apply(rawData, 2, function(x) abs(mean(x, na.rm = TRUE)) <= 1e-5))) 
     warning(paste0("It seems that you standardized your data before fitting your lavaan model. ",
                    "Note that this can undermine the results of the cross-validation due to dependencies between ",
                    "the subsets. Consider re-fitting your model with unstandardized data and use standardize = TRUE ",

--- a/R/initializeSEM.R
+++ b/R/initializeSEM.R
@@ -429,6 +429,13 @@
     rawData <- try(lavaan::lavInspect(lavaanModel, "data"))
     if(is(rawData, "try-error")) 
       stop("Error while extracting raw data from lavaanModel. Please fit the model using the raw data set, not the covariance matrix.")
+    
+    # remove empty rows:
+    if(any(apply(rawData, 1, function(x) all(is.na(x))))){
+        warning("Your data set has rows where all observations are missing. lessSEM will",
+                "remove those rows, but it is recommended to do so before fitting the models.")
+        rawData <- rawData[!apply(rawData, 1, function(x) all(is.na(x))),,drop = FALSE]
+    }
     checkFit <- TRUE
     
   }else{

--- a/R/regularizeSEMWithCustomPenalty.R
+++ b/R/regularizeSEMWithCustomPenalty.R
@@ -36,7 +36,7 @@
   
   if(lavaanModel@Options$estimator != "ML") stop("lavaanModel must be fit with ml estimator.")
   
-  rawData <- try(lavaan::lavInspect(lavaanModel, "data"))
+  rawData <- try(.getRawData(lavaanModel, NULL, "fiml")$rawData)
   if(is(rawData, "try-error")) stop("Error while extracting raw data from lavaanModel. Please fit the model using the raw data set, not the covariance matrix.")
   
   sampleSize <- nrow(rawData)


### PR DESCRIPTION
lessSEM throws errors if there are subgroups with only a single observation or no observations at all. This was due to subsetting in R matrices resulting in a vector instead of a matrix in those cases. Added ,drop = FALSE to handle those cases. Thanks to @B260198 for finding this issue!